### PR TITLE
Change h2 version back to 1.4.196.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <version>1.4.199</version>
+            <version>1.4.196</version>
         </dependency>
         <dependency>
             <groupId>org.hibernate</groupId>


### PR DESCRIPTION
Changed h2 driver version to 1.4.196 because IntelliJIDEA doesn't have h2 drivers for 1.4.199 only for 1.4.196 or 1.4.200.